### PR TITLE
CAC-0017: Basic Logic for MIsterX

### DIFF
--- a/Client/Assets/Code/Enum/EPlayerType.cs
+++ b/Client/Assets/Code/Enum/EPlayerType.cs
@@ -8,7 +8,7 @@ namespace ScotlandYard.Enums
 { 
     public enum EPlayerType
     {
-        DETECTIVE,
-        MISTERX
+        MISTERX,
+        DETECTIVE
     }
 }

--- a/Client/Assets/Code/Scripts/Events/GameEvents.cs
+++ b/Client/Assets/Code/Scripts/Events/GameEvents.cs
@@ -18,6 +18,7 @@ namespace ScotlandYard.Events
 
         public event EventHandler<int> OnMakeNextMove;
         public event EventHandler<PlayerEventArgs> OnPlayerMoveFinished;
+        public event EventHandler<ETicket> OnDetectiveTicketRemoved;
 
         public event EventHandler<int> OnRoundHasEnded;
 
@@ -110,6 +111,11 @@ namespace ScotlandYard.Events
         public void LanguageChanged(object sender, EventArgs args)
         {
             OnLanguageChanged?.Invoke(sender, args);
+        }
+
+        public void DetectiveTicketRemoved(object sender, ETicket ticket)
+        {
+            OnDetectiveTicketRemoved?.Invoke(sender, ticket);
         }
     }
 }

--- a/Client/Assets/Code/Scripts/Helper/HighlightBehavior.cs
+++ b/Client/Assets/Code/Scripts/Helper/HighlightBehavior.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using ScotlandYard.Scripts.Street;
 using ScotlandYard.Scripts.PlayerScripts;
+using ScotlandYard.Events;
 
 namespace ScotlandYard.Scripts.Helper
 {
@@ -16,11 +17,19 @@ namespace ScotlandYard.Scripts.Helper
 
             //highlight all Points, that are accessable by the player
             var targets = MovementHelper.GetTargets(agent);
-            foreach (GameObject go in targets)
+            if(targets.Count > 0)
             {
-                StreetPoint point = go.GetComponent<StreetPoint>();
-                prevHighlightedPoints.Add(point);
-                point.IsHighlighted = true;
+                foreach (GameObject go in targets)
+                {
+                    StreetPoint point = go.GetComponent<StreetPoint>();
+                    prevHighlightedPoints.Add(point);
+                    point.IsHighlighted = true;
+                }
+            }
+            else
+            {
+                agent.HasLost = true;
+                GameEvents.Current.PlayerMoveFinished(null, new PlayerEventArgs(agent));
             }
         }
 

--- a/Client/Assets/Code/Scripts/PlayerScripts/AIPlayer.cs
+++ b/Client/Assets/Code/Scripts/PlayerScripts/AIPlayer.cs
@@ -1,4 +1,5 @@
 ﻿using ScotlandYard.Enums;
+using ScotlandYard.Events;
 using ScotlandYard.Interface;
 using ScotlandYard.Scripts.Helper;
 using ScotlandYard.Scripts.Street;
@@ -28,15 +29,23 @@ namespace ScotlandYard.Scripts.PlayerScripts
             // determine street
             StreetPoint currentPoint = Position.GetComponent<StreetPoint>();
             List<GameObject> targets = MovementHelper.GetTargets(this);
-            int index = System.Convert.ToInt32(Random.Range(0, targets.Count - 1));
+            if(targets.Count > 0)
+            {
+                int index = System.Convert.ToInt32(Random.Range(0, targets.Count - 1));
 
-            // pay ticket
-            IStreet street = currentPoint.GetPathByPosition(Position, targets[index]);
-            var cost = street.ReturnTicketCost().Where(c => HasTicket(c)).ToArray();
-            RemoveTicket(cost[System.Convert.ToInt32(Random.Range(0, cost.Length - 1))]);
+                // pay ticket
+                IStreet street = currentPoint.GetPathByPosition(Position, targets[index]);
+                var cost = street.ReturnTicketCost().Where(c => HasTicket(c)).ToArray();
+                RemoveTicket(cost[System.Convert.ToInt32(Random.Range(0, cost.Length - 1))]);
 
-            // move
-            StartCoroutine(nameof(Move), street);
+                // move
+                StartCoroutine(nameof(Move), street);
+            }
+            else
+            {
+                HasLost = true;
+                GameEvents.Current.PlayerMoveFinished(this, new PlayerEventArgs(this));
+            }
         }
     }
 }

--- a/Client/Assets/Code/Scripts/PlayerScripts/Agent.cs
+++ b/Client/Assets/Code/Scripts/PlayerScripts/Agent.cs
@@ -26,7 +26,7 @@ namespace ScotlandYard.Scripts.PlayerScripts
         protected bool isMoving = false;
 
         //Properties
-        public EPlayerType PlayerType { get; set; }
+        public EPlayerType PlayerType { get => type; set => type = value; }
         public string AgentName { get => agentName; set => agentName = value; }
         public string ID { get => id; set => id = value; }
         public bool HasLost
@@ -38,14 +38,6 @@ namespace ScotlandYard.Scripts.PlayerScripts
                 {
                     hasLost = value;
                     Debug.Log($"{AgentName} lost this Game.");
-                    switch (PlayerType)
-                    {
-                        case EPlayerType.MISTERX:
-                            GameEvents.Current.DetectivesWon(null, null);
-                            break;
-                        default:
-                            break;
-                    }
                 }
             }
         }
@@ -63,8 +55,11 @@ namespace ScotlandYard.Scripts.PlayerScripts
             {
                 if(value != position)
                 {
-                    position.GetComponent<StreetPoint>().IsOccupied = false;
-                    value.GetComponent<StreetPoint>().IsOccupied = true;
+                    if(PlayerType != EPlayerType.MISTERX)
+                    {
+                        position.GetComponent<StreetPoint>().IsOccupied = false;
+                        value.GetComponent<StreetPoint>().IsOccupied = true;
+                    }
 
                     position = value;
                 }
@@ -105,8 +100,8 @@ namespace ScotlandYard.Scripts.PlayerScripts
 
                 yield return new WaitForSeconds(0.2f);
 
-                Debug.Log($"{AgentName} reached the Destination {this.Position.GetComponent<StreetPoint>().name}");
-                Debug.Log($"Tickets left: Taxi = {Tickets[ETicket.TAXI]}, Bus = {Tickets[ETicket.BUS]}, Underground = {Tickets[ETicket.UNDERGROUND]}");
+                Debug.Log($"{AgentName} reached the Destination {this.Position.GetComponent<StreetPoint>().name}\n"
+                    + $"Tickets left: Taxi = {Tickets[ETicket.TAXI]}, Bus = {Tickets[ETicket.BUS]}, Underground = {Tickets[ETicket.UNDERGROUND]}");
                 this.StreetPath = null;
 
                 isMoving = false;
@@ -191,6 +186,11 @@ namespace ScotlandYard.Scripts.PlayerScripts
 
         public virtual void RemoveTicket(ETicket ticket)
         {
+            if(PlayerType == EPlayerType.DETECTIVE)
+            {
+                GameEvents.Current.DetectiveTicketRemoved(this, ticket);
+            }
+
             if (HasTicket(ticket))
             {
                 Tickets[ticket]--;

--- a/Client/Assets/Scenes/TestScene.unity
+++ b/Client/Assets/Scenes/TestScene.unity
@@ -1440,6 +1440,55 @@ Transform:
   m_Father: {fileID: 859702743}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &454762321
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 454762323}
+  - component: {fileID: 454762322}
+  m_Layer: 0
+  m_Name: EasyAI (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &454762322
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 454762321}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 873b65cb7270c1c4682457796e4b582d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  agentName: COM 2
+  type: 1
+  speed: 5
+  position: {fileID: 1933341906}
+  difficulty: 0
+--- !u!4 &454762323
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 454762321}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -4.95, y: -4.083984, z: -0.26}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1195382149}
+  m_Father: {fileID: 0}
+  m_RootOrder: 14
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &497984605
 GameObject:
   m_ObjectHideFlags: 0
@@ -4601,7 +4650,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Profile: {fileID: 11400000, guid: e9a9e0374f549a94abbf713a37077a0e, type: 2}
   m_StaticLightingSkyUniqueID: 1
-  m_SkySettings: {fileID: 2062862583}
+  m_SkySettings: {fileID: 1384809780}
   m_SkySettingsFromProfile: {fileID: 7488742677745068149, guid: e9a9e0374f549a94abbf713a37077a0e,
     type: 2}
 --- !u!4 &1185691485
@@ -4844,6 +4893,99 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 36e58edc3005ecb4a9f22223e114a362, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &1195382148
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1195382149}
+  - component: {fileID: 1195382152}
+  - component: {fileID: 1195382151}
+  - component: {fileID: 1195382150}
+  m_Layer: 0
+  m_Name: Sphere
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1195382149
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1195382148}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.5, z: 0}
+  m_LocalScale: {x: 0.8, y: 0.8, z: 0.8}
+  m_Children: []
+  m_Father: {fileID: 454762323}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!135 &1195382150
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1195382148}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &1195382151
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1195382148}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: b94fe34eeb7ae444da92cf92c826585c, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1195382152
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1195382148}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1001 &1202893663
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5395,6 +5537,7 @@ MonoBehaviour:
   agentList:
   - {fileID: 859702744}
   - {fileID: 1179013860}
+  - {fileID: 454762322}
 --- !u!114 &1277524524
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -6022,6 +6165,107 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
+--- !u!114 &1384809780
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 59b6606ef2548734bb6d11b9d160bc7e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  active: 1
+  m_AdvancedMode: 0
+  rotation:
+    m_OverrideState: 0
+    m_Value: 0
+    min: 0
+    max: 360
+  skyIntensityMode:
+    m_OverrideState: 0
+    m_Value: 0
+  exposure:
+    m_OverrideState: 0
+    m_Value: 10
+  multiplier:
+    m_OverrideState: 0
+    m_Value: 1
+    min: 0
+  upperHemisphereLuxValue:
+    m_OverrideState: 0
+    m_Value: 1
+    min: 0
+  upperHemisphereLuxColor:
+    m_OverrideState: 0
+    m_Value: {x: 0, y: 0, z: 0}
+  desiredLuxValue:
+    m_OverrideState: 0
+    m_Value: 20000
+  updateMode:
+    m_OverrideState: 0
+    m_Value: 0
+  updatePeriod:
+    m_OverrideState: 0
+    m_Value: 0
+    min: 0
+  includeSunInBaking:
+    m_OverrideState: 0
+    m_Value: 0
+  hdriSky:
+    m_OverrideState: 0
+    m_Value: {fileID: 8900000, guid: 8253d41e6e8b11a4cbe77a4f8f82934d, type: 3}
+  enableBackplate:
+    m_OverrideState: 0
+    m_Value: 0
+  backplateType:
+    m_OverrideState: 0
+    m_Value: 0
+  groundLevel:
+    m_OverrideState: 0
+    m_Value: 0
+  scale:
+    m_OverrideState: 0
+    m_Value: {x: 32, y: 32}
+  projectionDistance:
+    m_OverrideState: 0
+    m_Value: 16
+    min: 0.0000001
+  plateRotation:
+    m_OverrideState: 0
+    m_Value: 0
+    min: 0
+    max: 360
+  plateTexRotation:
+    m_OverrideState: 0
+    m_Value: 0
+    min: 0
+    max: 360
+  plateTexOffset:
+    m_OverrideState: 0
+    m_Value: {x: 0, y: 0}
+  blendAmount:
+    m_OverrideState: 0
+    m_Value: 0
+    min: 0
+    max: 100
+  shadowTint:
+    m_OverrideState: 0
+    m_Value: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+    hdr: 0
+    showAlpha: 1
+    showEyeDropper: 1
+  pointLightShadow:
+    m_OverrideState: 0
+    m_Value: 0
+  dirLightShadow:
+    m_OverrideState: 0
+    m_Value: 0
+  rectLightShadow:
+    m_OverrideState: 0
+    m_Value: 0
 --- !u!1 &1413791986
 GameObject:
   m_ObjectHideFlags: 0
@@ -8139,107 +8383,6 @@ Transform:
   m_Father: {fileID: 1607648006}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: -82.12701, z: 0}
---- !u!114 &2062862583
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 59b6606ef2548734bb6d11b9d160bc7e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  active: 1
-  m_AdvancedMode: 0
-  rotation:
-    m_OverrideState: 0
-    m_Value: 0
-    min: 0
-    max: 360
-  skyIntensityMode:
-    m_OverrideState: 0
-    m_Value: 0
-  exposure:
-    m_OverrideState: 0
-    m_Value: 10
-  multiplier:
-    m_OverrideState: 0
-    m_Value: 1
-    min: 0
-  upperHemisphereLuxValue:
-    m_OverrideState: 0
-    m_Value: 1
-    min: 0
-  upperHemisphereLuxColor:
-    m_OverrideState: 0
-    m_Value: {x: 0, y: 0, z: 0}
-  desiredLuxValue:
-    m_OverrideState: 0
-    m_Value: 20000
-  updateMode:
-    m_OverrideState: 0
-    m_Value: 0
-  updatePeriod:
-    m_OverrideState: 0
-    m_Value: 0
-    min: 0
-  includeSunInBaking:
-    m_OverrideState: 0
-    m_Value: 0
-  hdriSky:
-    m_OverrideState: 0
-    m_Value: {fileID: 8900000, guid: 8253d41e6e8b11a4cbe77a4f8f82934d, type: 3}
-  enableBackplate:
-    m_OverrideState: 0
-    m_Value: 0
-  backplateType:
-    m_OverrideState: 0
-    m_Value: 0
-  groundLevel:
-    m_OverrideState: 0
-    m_Value: 0
-  scale:
-    m_OverrideState: 0
-    m_Value: {x: 32, y: 32}
-  projectionDistance:
-    m_OverrideState: 0
-    m_Value: 16
-    min: 0.0000001
-  plateRotation:
-    m_OverrideState: 0
-    m_Value: 0
-    min: 0
-    max: 360
-  plateTexRotation:
-    m_OverrideState: 0
-    m_Value: 0
-    min: 0
-    max: 360
-  plateTexOffset:
-    m_OverrideState: 0
-    m_Value: {x: 0, y: 0}
-  blendAmount:
-    m_OverrideState: 0
-    m_Value: 0
-    min: 0
-    max: 100
-  shadowTint:
-    m_OverrideState: 0
-    m_Value: {r: 0.5, g: 0.5, b: 0.5, a: 1}
-    hdr: 0
-    showAlpha: 1
-    showEyeDropper: 1
-  pointLightShadow:
-    m_OverrideState: 0
-    m_Value: 0
-  dirLightShadow:
-    m_OverrideState: 0
-    m_Value: 0
-  rectLightShadow:
-    m_OverrideState: 0
-    m_Value: 0
 --- !u!1 &2071333831
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
- changes for the initialisation of Agents
  - changed order of the PlayerTypes in EPlayerType, so when Agents are sorted acording to their PlayerType MisterX would be the first
  - if multiple players have selected the role of MisterX a random one of them will be selected (same thing happens when no one selected to be MisterX)
  - at the end of the initialisation agentList is sorted (first MisterX then all Detectives)
- general logic changes for MisterX gameplay
  - Event OnDetectiveTicketRemoved added. If this event is invoked PlayerController.Current_OnDetectiveTicketRemoved(...) is called, which adds one ticket of given type to MisterX
  - new loosing condition added to PlayerController.CheckIfPlayerHasLost(...) (checks if Detective is on the same StreetPoint as MisterX, if so the Detectives win)
  - StreetPoints are now marked occupied in the setter of Position in class Agent, because multiple Detectives are not allowed to stay on the same StreetPoint. However if the Agent is MisterX, than the StreetPoint is not marked, because Detectives catch MisterX by moving on the same position
  - MisterX is now hidden for other Players and will only be visible in rounds given by the array detectionRounds (RounManager)
- Bug Fixes
  - NullPointer fixed that occured, when an Agent is surounded by other Agents and can't move (fix in HighlightBehavior.HighlightAccesPoints(...) and AIPlayer.MoveRandomly())
- New AIPlayer added in the TestScene